### PR TITLE
Fix dependency issue by adding add_dependencies to CMakeLists.txt

### DIFF
--- a/rosns3_client/CMakeLists.txt
+++ b/rosns3_client/CMakeLists.txt
@@ -53,6 +53,12 @@ src/client.cpp
 src/Robot.cpp
 )
 
+add_dependencies(
+  ${PROJECT_NAME}
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+)
+
 target_link_libraries(
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}     


### PR DESCRIPTION
Dear Malintha Fernando,

Thank you for your prompt response and suggestions regarding the rosns3_client project.

I tried building the rosns3_client first using catkin build rosns3_client and then performing a full build with catkin build as you recommended. However, I still encountered issues with the recursive dependency of the message.

After some investigation, I found a solution that resolved the compilation problem effectively. By adding the following lines to the **rosns3_client/CMakeLists.txt** file:

```
add_dependencies(
  ${PROJECT_NAME}
  ${${PROJECT_NAME}_EXPORTED_TARGETS}
  ${catkin_EXPORTED_TARGETS}
)
```
This addition ensured that the necessary dependencies were correctly handled during the build process, and the issue was resolved. Specifically, placing this add_dependencies command after the **add_executable** command and before the **target_link_libraries** command ensured that all dependencies were properly managed.

I hope this information is helpful for you and others who might encounter a similar problem. Thank you again for your support and the valuable work you have done with this project.

Best regards,
James